### PR TITLE
Not compatible with Windows OS

### DIFF
--- a/farasa/__base.py
+++ b/farasa/__base.py
@@ -15,14 +15,17 @@ from tqdm import tqdm
 class FarasaBase:
     task = None
     __base_dir = Path(__file__).parent.absolute()
-    __bin_dir = f'{__base_dir}/farasa_bin'
-    __bin_lib_dir = f'{__bin_dir}/lib'
+    __bin_dir = Path(f'{__base_dir}/farasa_bin')
+    __bin_lib_dir = Path(f'{__bin_dir}/lib')
+
+    # shlex not compatible with Windows replace it with list()
+    __BASE_CMD = ['java', '-jar']
     __APIs = {
-        'segment':shlex.split(f'java -jar {__bin_lib_dir}/FarasaSegmenterJar.jar'),
-        'stem' : shlex.split(f'java -jar {__bin_lib_dir}/FarasaSegmenterJar.jar -l true'),
-        'NER' : shlex.split(f'java -jar {__bin_dir}/FarasaNERJar.jar'),
-        'POS' : shlex.split(f'java -jar {__bin_dir}/FarasaPOSJar.jar'),
-        'diacritize' : shlex.split(f'java -jar {__bin_dir}/FarasaDiacritizeJar.jar'),
+        'segment': __BASE_CMD + [str(__bin_lib_dir / 'FarasaSegmenterJar.jar')],
+        'stem': __BASE_CMD + [str(__bin_lib_dir / 'FarasaSegmenterJar.jar'), '-l', 'true'],
+        'NER': __BASE_CMD + [str(__bin_dir / 'FarasaNERJar.jar')],
+        'POS': __BASE_CMD + [str(__bin_dir / 'FarasaPOSJar.jar')],
+        'diacritize': __BASE_CMD + [str(__bin_dir / 'FarasaDiacritizeJar.jar')]
     }
     __interactive = False
     __task_proc = None

--- a/farasa/__base.py
+++ b/farasa/__base.py
@@ -115,20 +115,19 @@ class FarasaBase:
             print(proc_err)
             raise Exception("We could not check for java version on the machine. Please make sure you have installed Java 1.7+ and add it to your PATH.")
 
-
     def _run_task(self, btext):
         assert btext is not None
-        with tempfile.NamedTemporaryFile(dir=f'{self.__base_dir}/tmp',) as itmp,\
-                    tempfile.NamedTemporaryFile(dir=f'{self.__base_dir}/tmp',) as otmp:
+        with tempfile.NamedTemporaryFile(dir=f'{self.__base_dir}/tmp', delete=False) as itmp, \
+                tempfile.NamedTemporaryFile(dir=f'{self.__base_dir}/tmp', delete=False) as otmp:
             itmp.write(btext)
-            itmp.flush() # https://stackoverflow.com/questions/46004774/python-namedtemporaryfile-appears-empty-even-after-data-is-written
-            proc = subprocess.run(self.__APIs[self.task]+['-i',itmp.name,'-o',otmp.name],\
-                                    capture_output=True)
+            itmp.flush()  # https://stackoverflow.com/questions/46004774/python-namedtemporaryfile-appears-empty-even-after-data-is-written
+            proc = subprocess.run(self.__APIs[self.task] + ['-i', itmp.name, '-o', otmp.name], \
+                                  capture_output=True)
             if proc.returncode == 0:
                 return otmp.read().decode('utf8').strip()
             else:
-                print("error occured!",otmp.read().decode('utf8').strip())
-                print("return code:",proc.returncode)
+                print("error occurred!", proc.stderr)
+                print("return code:", proc.returncode)
                 raise Exception('Internal Error occured!')
 
     

--- a/farasa/__base.py
+++ b/farasa/__base.py
@@ -1,9 +1,6 @@
-import os
 import sys
 import subprocess
-import shlex
 import warnings
-import time
 import re
 import tempfile
 from pathlib import Path
@@ -11,6 +8,7 @@ import requests
 import zipfile
 import io
 from tqdm import tqdm
+
 
 class FarasaBase:
     task = None
@@ -50,28 +48,28 @@ class FarasaBase:
     def _check_toolkit_binaries(self):
         download = False
         # check in bin folder:
-        for jar in ('FarasaNERJar','FarasaPOSJar','FarasaDiacritizeJar'):
+        for jar in ('FarasaNERJar', 'FarasaPOSJar', 'FarasaDiacritizeJar'):
             if not Path(f'{self.__bin_dir}/{jar}.jar').is_file():
                 download = True
                 break
-        if download or not Path(f'{self.__bin_lib_dir}/FarasaSegmenterJar.jar').is_file(): # last check for binaries in farasa_bin/lib
+        if download or not Path(
+                f'{self.__bin_lib_dir}/FarasaSegmenterJar.jar').is_file():  # last check for binaries in farasa_bin/lib
             print("some binaries are not existed..")
             self._download_binaries()
 
     def _get_content_with_progressbar(self, request):
-        totalsize = int(request.headers.get('content-length',0))
+        totalsize = int(request.headers.get('content-length', 0))
         blocksize = 3413334
-        bar = tqdm(total=totalsize, unit='iB',unit_scale=True, ncols=5, dynamic_ncols=True, file=sys.stdout)
+        bar = tqdm(total=totalsize, unit='iB', unit_scale=True, ncols=5, dynamic_ncols=True, file=sys.stdout)
         content = None
         for data in request.iter_content(blocksize):
             bar.update(len(data))
             if content is None:
                 content = data
             else:
-                content+=data
+                content += data
         return content
-            
-    
+
     def _download_binaries(self):
         print("downloading zipped binaries...")
         try:
@@ -87,33 +85,30 @@ class FarasaBase:
             print("an error occured")
             print(e)
 
-
-            
-
     def _initialize_task(self):
         word = 'اختبار'
-        word+='\n'
+        word += '\n'
         bword = str.encode(word)
         self.__task_proc = subprocess.Popen(self.__APIs[self.task],
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+                                            stdin=subprocess.PIPE,
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.PIPE)
         return self._run_task_interactive(bword)
-
-            
 
     def _check_java_version(self):
         try:
-            version_proc_output = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT,encoding='utf8',text=True)
+            version_proc_output = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT,
+                                                          encoding='utf8', text=True)
             version_pattern = r'\"(\d+\.\d+).*\"'
-            java_version = float(re.search(version_pattern,version_proc_output).groups()[0])
+            java_version = float(re.search(version_pattern, version_proc_output).groups()[0])
             if java_version >= 1.7:
                 print(f"Your java version is {java_version} which is compatiple with Farasa ")
             else:
                 warnings.warn('You are using old version of java. Farasa is compatiple with Java 7 and above ')
         except subprocess.CalledProcessError as proc_err:
             print(proc_err)
-            raise Exception("We could not check for java version on the machine. Please make sure you have installed Java 1.7+ and add it to your PATH.")
+            raise Exception(
+                "We could not check for java version on the machine. Please make sure you have installed Java 1.7+ and add it to your PATH.")
 
     def _run_task(self, btext):
         assert btext is not None
@@ -130,10 +125,9 @@ class FarasaBase:
                 print("return code:", proc.returncode)
                 raise Exception('Internal Error occured!')
 
-    
     def _run_task_interactive(self, btext):
         assert btext is not None and type(btext) == bytes
-        assert self.__interactive == True 
+        assert self.__interactive == True
         assert self.__task_proc is not None
         self.__task_proc.stdin.flush()
         self.__task_proc.stdin.write(btext)
@@ -141,28 +135,28 @@ class FarasaBase:
         output = self.__task_proc.stdout.readline().decode('utf8').strip()
         self.__task_proc.stdout.flush()
         return output
-    
+
     def _do_task_interactive(self, strip_text):
         outputs = []
         for line in strip_text.split('\n'):
-            newlined_line = line+'\n'
+            newlined_line = line + '\n'
             byted_newlined_line = str.encode(newlined_line)
             output = self._run_task_interactive(byted_newlined_line)
             if output:
                 outputs.append(output)
         return '\n'.join(outputs)
-    
-    def _do_task_standalone(self,strip_text):
-        byted_strip_text = str.encode(strip_text)    
+
+    def _do_task_standalone(self, strip_text):
+        byted_strip_text = str.encode(strip_text)
         return self._run_task(btext=byted_strip_text)
 
     def _do_task(self, text):
         strip_text = text.strip()
         if self.__interactive:
-            return self._do_task_interactive(strip_text)        
+            return self._do_task_interactive(strip_text)
         else:
             return self._do_task_standalone(strip_text)
 
     def terminate(self):
         self.__task_proc.terminate()
-    
+

--- a/farasa/__base.py
+++ b/farasa/__base.py
@@ -19,7 +19,8 @@ class FarasaBase:
     __bin_lib_dir = Path(f'{__bin_dir}/lib')
 
     # shlex not compatible with Windows replace it with list()
-    __BASE_CMD = ['java', '-jar']
+    # set java encoding with option `-Dfile.encoding=UTF-8`
+    __BASE_CMD = ['java', '-Dfile.encoding=UTF-8', '-jar']
     __APIs = {
         'segment': __BASE_CMD + [str(__bin_lib_dir / 'FarasaSegmenterJar.jar')],
         'stem': __BASE_CMD + [str(__bin_lib_dir / 'FarasaSegmenterJar.jar'), '-l', 'true'],

--- a/farasa/diacratizer.py
+++ b/farasa/diacratizer.py
@@ -1,8 +1,8 @@
 from .__base import FarasaBase
 
-class FarasaDiacritizer(FarasaBase):
 
+class FarasaDiacritizer(FarasaBase):
     task = 'diacritize'
 
-    def diacritize(self,text):
+    def diacritize(self, text):
         return self._do_task(text=text)

--- a/farasa/ner.py
+++ b/farasa/ner.py
@@ -1,8 +1,8 @@
 from .__base import FarasaBase
 
-class FarasaNamedEntityRecognizer(FarasaBase):
 
+class FarasaNamedEntityRecognizer(FarasaBase):
     task = 'NER'
 
-    def recognize(self,text):
+    def recognize(self, text):
         return self._do_task(text=text)

--- a/farasa/pos.py
+++ b/farasa/pos.py
@@ -1,8 +1,8 @@
 from .__base import FarasaBase
 
-class FarasaPOSTagger(FarasaBase):
 
+class FarasaPOSTagger(FarasaBase):
     task = 'POS'
 
-    def tag(self,text):
+    def tag(self, text):
         return self._do_task(text=text)

--- a/farasa/segmenter.py
+++ b/farasa/segmenter.py
@@ -1,8 +1,8 @@
 from .__base import FarasaBase
 
-class FarasaSegmenter(FarasaBase):
 
+class FarasaSegmenter(FarasaBase):
     task = 'segment'
-    
+
     def segment(self, text):
         return self._do_task(text=text)

--- a/farasa/stemmer.py
+++ b/farasa/stemmer.py
@@ -1,8 +1,8 @@
 from .__base import FarasaBase
 
+
 class FarasaStemmer(FarasaBase):
-    
     task = 'stem'
-    
+
     def stem(self, text):
         return self._do_task(text=text)


### PR DESCRIPTION
# Not compatible with Windows OS

Thank you for your hard work on this lib.

## Issues

But i find out on Windows platform there are several issues

- `shlex.split()` can't process directory saparator `\`
- CMD encoding is different with different regions (i.e.: in China CMD encoding is GBK), when at `Interactive` mode it's can't get right encoding from CMD output
- At mode `Standalone`, Python API `tempfile.NamedTemporaryFile` can not write content in tmp directory even with `tmpfile.flush()` is called

So, i do some test about above issues

### about shlex.split()

file `issue_test.py` under `E:\workspace\python\farasapy\`

```python
from pathlib import Path
import shlex

cur_dir = Path(__file__).parent.absolute()
cmd = f'java -jar {cur_dir}/xxx.jar'
cmd_split = shlex.split(cmd)

print('cur_dir: ', cur_dir)
print('cmd: ', cmd)
print('cmd split parts: ', cmd_split)
```

run result

```
(venv) E:\workspace\python\farasapy>python .\issue_test.py
cur_dir:  E:\workspace\python\farasapy
cmd:  java -jar E:\workspace\python\farasapy/xxx.jar
cmd split parts:  ['java', '-jar', 'E:workspacepythonfarasapy/xxx.jar']
```

after called `shlex.split()` character `\` was missing in result `['java', '-jar', 'E:workspacepythonfarasapy/xxx.jar']`


### about mode 「interactive」

when run interactive mode will show these error

```
  File "E:\workspace\python\machine_classifier\venv\lib\site-packages\farasa\__base.py", line 135, in _run_task_interactive
    output = self.__task_proc.stdout.readline().decode('utf8').strip()

UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 0-1: invalid continuation byte
```


### about mode 「standalone」

run `tests.py` under project farasapy, will give error like this

```
----------------------------------------
Farasa features, noninteractive mode.
----------------------------------------
perform system check...
check java version...
Your java version is 1.8 which is compatiple with Farasa
check toolkit binaries...
Dependencies seem to be satisfied..
task [SEGMENT] is initialized in [34mSTANDALONE [37mmode...
error occured!
return code: 1
Traceback (most recent call last):
  File ".\tests.py", line 25, in <module>
    segmented = segmenter.segment(sample)
  File "E:\workspace\python\farasapy\farasa\segmenter.py", line 8, in segment
    return self._do_task(text=text)
  File "E:\workspace\python\farasapy\farasa\__base.py", line 160, in _do_task
    return self._do_task_standalone(strip_text)
  File "E:\workspace\python\farasapy\farasa\__base.py", line 153, in _do_task_standalone
    return self._run_task(btext=byted_strip_text)
  File "E:\workspace\python\farasapy\farasa\__base.py", line 128, in _run_task
    raise Exception('Internal Error occured!')
Exception: Internal Error occured!
```

no useful information, so i change the code about function `_run_task()`

```python
def _run_task(self, btext):
    assert btext is not None
    with tempfile.NamedTemporaryFile(dir=f'{self.__base_dir}/tmp',) as itmp,\
                tempfile.NamedTemporaryFile(dir=f'{self.__base_dir}/tmp',) as otmp:
        itmp.write(btext)
        itmp.flush() # https://stackoverflow.com/questions/46004774/python-namedtemporaryfile-appears-empty-even-after-data-is-written
        proc = subprocess.run(self.__APIs[self.task]+['-i',itmp.name,'-o',otmp.name],\
                                capture_output=True)
        print(proc.stdout, proc.stderr)
        if proc.returncode == 0:
            return otmp.read().decode('utf8').strip()
        else:
            print("error occured!",otmp.read().decode('utf8').strip())
            print("return code:",proc.returncode)
            raise Exception('Internal Error occured!')
```

add line `print(proc.stdout, proc.stderr)`, then i get errors from Java

```
b'' b'Initializing the system ....\rSystem ready!               \r\nException in thread "main" java.io.FileNotFoundException: E:\\workspace\\python\\farasapy\\farasa\\tmp\\tmpltwyiodu (\xe5\x8f\xa6\xe4\xb8\x80\xe4\xb8\xaa\xe7\xa8\x8b\xe5\xba\x8f\xe6\xad\xa3\xe5\x9c\xa8\xe4\xbd\xbf\xe7\x94\xa8\xe6\xad\xa4\xe6\x96\x87\xe4\xbb\xb6\xef\xbc\x8c\xe8\xbf\x9b\xe7\xa8\x8b\xe6\x97\xa0\xe6\xb3\x95\xe8\xae\xbf\xe9\x97\xae\xe3\x80\x82)\r\n\tat java.io.FileInputStream.open0(Native Method)\r\n\tat java.io.FileInputStream.open(FileInputStream.java:195)\r\n\tat java.io.FileInputStream.<init>(FileInputStream.java:138)\r\n\tat com.qcri.farasa.segmenter.TestCase.openFileForReading(TestCase.java:633)\r\n\tat com.qcri.farasa.segmenter.TestCase.processFile(TestCase.java:128)\r\n\tat com.qcri.farasa.segmenter.TestCase.main(TestCase.java:105)\r\n'
```

it's cannot find tempfile, so i check Python docs [https://docs.python.org/3/library/tempfile.html](https://docs.python.org/3/library/tempfile.html), on Windows there is problem with not have param `delete=False` in `tempfile.NamedTemporaryFile()`


## Solution

i will submit a PR


### about shlex.split() & mode 「interactive」

1. change `shlex.split()` to `list()` 
2. set java encoding with option `-Dfile.encoding=UTF-8`

```python
    task = None
    __base_dir = Path(__file__).parent.absolute()
    __bin_dir = Path(f'{__base_dir}/farasa_bin')
    __bin_lib_dir = Path(f'{__bin_dir}/lib')

    # shlex not compatible with Windows replace it with list()
    # set java encoding with option `-Dfile.encoding=UTF-8`
    __BASE_CMD = ['java', '-Dfile.encoding=UTF-8', '-jar']
    __APIs = {
        'segment': __BASE_CMD + [str(__bin_lib_dir / 'FarasaSegmenterJar.jar')],
        'stem': __BASE_CMD + [str(__bin_lib_dir / 'FarasaSegmenterJar.jar'), '-l', 'true'],
        'NER': __BASE_CMD + [str(__bin_dir / 'FarasaNERJar.jar')],
        'POS': __BASE_CMD + [str(__bin_dir / 'FarasaPOSJar.jar')],
        'diacritize': __BASE_CMD + [str(__bin_dir / 'FarasaDiacritizeJar.jar')]
    }
```


### about mode 「standalone」

we set `tempfile.NamedTemporaryFile(dir='...', delete=False)`

```python
    def _run_task(self, btext):
        assert btext is not None
        with tempfile.NamedTemporaryFile(dir=f'{self.__base_dir}/tmp', delete=False) as itmp, \
                tempfile.NamedTemporaryFile(dir=f'{self.__base_dir}/tmp', delete=False) as otmp:
            itmp.write(btext)
            itmp.flush()  # https://stackoverflow.com/questions/46004774/python-namedtemporaryfile-appears-empty-even-after-data-is-written
            proc = subprocess.run(self.__APIs[self.task] + ['-i', itmp.name, '-o', otmp.name], \
                                  capture_output=True)
            if proc.returncode == 0:
                return otmp.read().decode('utf8').strip()
            else:
                print("error occured!", proc.stderr)
                print("return code:", proc.returncode)
                raise Exception('Internal Error occured!')
```


### other

code style not good, reformat core code [http://google.github.io/styleguide/pyguide.html](http://google.github.io/styleguide/pyguide.html)


## test

i test the code after change on Windows 10 & macOS Catalina, it's passed
