### PR TITLE
Fixed bug in `tag_segments`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 
@@ -27,7 +27,10 @@ setuptools.setup(
         "Environment :: Console",
     ],
     python_requires=">=3.6",
-    install_requires=["requests", "tqdm",],
+    install_requires=[
+        "requests",
+        "tqdm",
+    ],
 )
 
 # scripts=['farasa/__init__.py','farasa/farasa_bin/*','farasa/farasa_bin/lib/*','farasa/tmp/*'],

--- a/tests.py
+++ b/tests.py
@@ -6,80 +6,89 @@ from farasa.stemmer import FarasaStemmer
 
 
 # https://r12a.github.io/scripts/tutorial/summaries/arabic
-sample =\
-'''
-يُشار إلى أن اللغة العربية يتحدثها أكثر من 422 مليون نسمة ويتوزع متحدثوها في المنطقة المعروفة باسم الوطن العربي بالإضافة إلى العديد من المناطق الأخرى المجاورة مثل الأهواز وتركيا وتشاد والسنغال وإريتريا وغيرها.     وهي اللغة الرابعة من لغات منظمة الأمم المتحدة الرسمية الست.
-'''
+sample = """
+يُشار إلى أن اللغة العربية يتحدثها أكثر من 422 مليون نسمة ويتوزع متحدثوها في المنطقة المعروفة باسم الوطن العربي بالإضافة إلى العديد من المناطق الأخرى المجاورة مثل الأهواز وتركيا وتشاد والسنغال وإريتريا وغيرها.     وهي اللغة الرابعة من لغات منظمة الأمم المتحدة الرسمية الست منذ 99/9/1999. /
+"""
 
 
-'''
+"""
 ---------------------
 non interactive mode
 ---------------------
-'''
-print("original sample:",sample)
-print('----------------------------------------')
+"""
+print("original sample:", sample)
+print("----------------------------------------")
 print("Farasa features, noninteractive mode.")
-print('----------------------------------------')
+print("----------------------------------------")
 segmenter = FarasaSegmenter()
 segmented = segmenter.segment(sample)
-print("sample segmented:",segmented)
+print("sample segmented:", segmented)
 print("----------------------------------------------")
 
 stemmer = FarasaStemmer()
 stemmed = stemmer.stem(sample)
-print("sample stemmed:",stemmed)
+print("sample stemmed:", stemmed)
 print("----------------------------------------------")
 
 pos_tagger = FarasaPOSTagger()
 pos_tagged = pos_tagger.tag(sample)
-print("sample POS Tagged",pos_tagged)
+print("sample POS Tagged", pos_tagged)
+print("----------------------------------------------")
+
+pos_tagger_interactive = FarasaPOSTagger()
+pos_tagged_interactive = pos_tagger_interactive.tag_segments(sample)
+print("sample POS Tagged Segments", pos_tagged_interactive)
 print("----------------------------------------------")
 
 named_entity_recognizer = FarasaNamedEntityRecognizer()
 named_entity_recognized = named_entity_recognizer.recognize(sample)
-print("sample named entity recognized:",named_entity_recognized)
+print("sample named entity recognized:", named_entity_recognized)
 print("----------------------------------------------")
 
 diacritizer = FarasaDiacritizer()
 diacritized = diacritizer.diacritize(sample)
-print("sample diacritized:",diacritized)
+print("sample diacritized:", diacritized)
 print("----------------------------------------------")
 
-'''
+"""
 ---------------------
 interactive mode
 ---------------------
-'''
-print('----------------------------------------')
+"""
+print("----------------------------------------")
 print("Farasa features, interactive mode.")
-print('----------------------------------------')
+print("----------------------------------------")
 
 segmenter_interactive = FarasaSegmenter(interactive=True)
 segmented_interactive = segmenter_interactive.segment(sample)
-print("sample segmented (interactive):",segmented_interactive)
+print("sample segmented (interactive):", segmented_interactive)
 print("----------------------------------------------")
 
 stemmer_interactive = FarasaStemmer(interactive=True)
 stemmed_interactive = stemmer_interactive.stem(sample)
-print("sample stemmed (interactive):",stemmed_interactive)
+print("sample stemmed (interactive):", stemmed_interactive)
 print("----------------------------------------------")
 
 pos_tagger_interactive = FarasaPOSTagger(interactive=True)
 pos_tagged_interactive = pos_tagger_interactive.tag(sample)
-print("sample POS Tagged (interactive)",pos_tagged_interactive)
+print("sample POS Tagged (interactive)", pos_tagged_interactive)
+print("----------------------------------------------")
+
+pos_tagger_interactive = FarasaPOSTagger(interactive=True)
+pos_tagged_interactive = pos_tagger_interactive.tag_segments(sample)
+print("sample POS Tagged Segments (interactive)", pos_tagged_interactive)
 print("----------------------------------------------")
 
 named_entity_recognizer_interactive = FarasaNamedEntityRecognizer(interactive=True)
-named_entity_recognized_interactive = named_entity_recognizer_interactive.recognize(sample)
-print("sample named entity recognized (interactive):",named_entity_recognized_interactive)
+named_entity_recognized_interactive = named_entity_recognizer_interactive.recognize(
+    sample
+)
+print(
+    "sample named entity recognized (interactive):", named_entity_recognized_interactive
+)
 print("----------------------------------------------")
 
 diacritizer_interactive = FarasaDiacritizer(interactive=True)
 diacritized_interactive = diacritizer_interactive.diacritize(sample)
-print("sample diacritized (interactive):",diacritized_interactive)
+print("sample diacritized (interactive):", diacritized_interactive)
 print("----------------------------------------------")
-
-
-
-


### PR DESCRIPTION
How to replicate the bug:

```python
from farasa.pos import FarasaPOSTagger
pos_tagger = FarasaPOSTagger(interactive=True)
text = "يُشار/ إلى أن اللغة19/2/1995 العربية يتحدثها أكثر من 422 مليون نسمة ويتوزع متحدثوها في المنطقة المعروفة باسم الوطن العربي بالإضافة إلى العديد من المناطق الأخرى المجاورة مثل الأهواز وتركيا وتشاد والسنغال وإريتريا وغيرها. وهي اللغة الرابعة من لغات منظمة الأمم المتحدة الرسمية الست."
pos_tagger.tag_segments(text)
```
output:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~/search_engine/test_query_classifier.py in <module>
----> 1 pos_tagger.tag_segments(text)

~/miniconda3/envs/search_engine/lib/python3.8/site-packages/farasa/pos.py in tag_segments(self, text, combine_subtokens)
     72         if not combine_subtokens:
     73             for tagged_token in tagged_tokens:
---> 74                 token, tag = tagged_token.split("/")
     75                 token_object = TaggedToken(token, tag)
     76                 if not tokens_objects:

ValueError: too many values to unpack (expected 2)
```

In this pull request, The function now correctly checks for "/" before splitting and handles each case as it should.
I also added a test case. And fixed the setup on windows while I'm at it.